### PR TITLE
Minor fix for xBuild compatibility

### DIFF
--- a/Mono.Cecil.settings
+++ b/Mono.Cecil.settings
@@ -95,7 +95,7 @@
   <PropertyGroup>
     <CecilOverrides Condition="'$(CecilOverrides)' == ''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Mono.Cecil.overrides))\Mono.Cecil.overrides</CecilOverrides>
   </PropertyGroup>  
-  <Import Project="$(CecilOverrides)" Condition="Exists($(CecilOverrides))" />
+  <Import Project="'$(CecilOverrides)'" Condition="Exists('$(CecilOverrides)')" />
   
   <!-- This is an example of a custom override file -->
   <!--


### PR DESCRIPTION
Without colons, xBuild will error out on the import (and on the condition). MSBuild likes it, though...

@jbevain this is the change in #4 in mono/cecil.
